### PR TITLE
Support JSON container arrays

### DIFF
--- a/build/xsltforms.js
+++ b/build/xsltforms.js
@@ -6965,6 +6965,8 @@ XsltForms_browser.json2xml = function(eltname, json, root, inarray) {
 	if (json instanceof Array) {
 		if (inarray) {
 			ret += "<exml:anonymous exsi:maxOccurs=\"unbounded\">";
+		} else {
+		    ret += "<"+eltname+fullname+" exsi:maxOccurs=\"unbounded\">";
 		}
 		if (json.length === 0) {
 			ret += "<" + (eltname === "" ? "exml:anonymous" : eltname) + fullname + " exsi:maxOccurs=\"unbounded\" xsi:nil=\"true\"/>";
@@ -6975,6 +6977,8 @@ XsltForms_browser.json2xml = function(eltname, json, root, inarray) {
 		}
 		if (inarray) {
 			ret += "</exml:anonymous>";
+		} else {
+		    ret += "</"+eltname+">";
 		}
 	} else {
 		var xsdtype = "";

--- a/build/xsltforms.js
+++ b/build/xsltforms.js
@@ -6957,7 +6957,7 @@ XsltForms_instance.prototype.setProperty_ = function (node, property, value) {
 XsltForms_browser.json2xmlreg = new RegExp("^[A-Za-z_\xC0-\xD6\xD8-\xF6\xF8-\xFF][A-Za-z_\xC0-\xD6\xD8-\xF6\xF8-\xFF\-\.0-9\xB7]*$");
 XsltForms_browser.json2xml = function(eltname, json, root, inarray) {
 	var fullname = "";
-	if (eltname === "________" || eltname !== "" && !XsltForms_browser.json2xmlreg.test(eltname)) {
+	if (eltname === "________" || !(json instanceof Array) && eltname !== "" && !XsltForms_browser.json2xmlreg.test(eltname)) {
 		fullname = " exml:fullname=\"" + XsltForms_browser.escape(eltname) + "\"";
 		eltname = "________";
 	}


### PR DESCRIPTION
For example, in JSON-LD, a `@graph` array can wrap a sequence of objects. Container arrays are not preserved in the current `json2xml` serialization.
