### PR TITLE
xslt-sort.xhtml sort/@data-type corrected.

### DIFF
--- a/testsuite/xforms-examples/13-javascript/xslt-sort.xhtml
+++ b/testsuite/xforms-examples/13-javascript/xslt-sort.xhtml
@@ -85,7 +85,7 @@
       <xsl:template match="/">
         <data>
           <xsl:apply-templates select="data/item">
-            <xsl:sort type="string" select="fname"/>
+            <xsl:sort data-type="text" select="fname"/>
           </xsl:apply-templates>
         </data>
       </xsl:template>
@@ -102,7 +102,7 @@
       <xsl:template match="/">
         <data>
           <xsl:apply-templates select="data/item">
-            <xsl:sort type="string" select="lname"/>
+            <xsl:sort data-type="text" select="lname"/>
           </xsl:apply-templates>
         </data>
       </xsl:template>
@@ -119,7 +119,7 @@
       <xsl:template match="/">
         <data>
           <xsl:apply-templates select="data/item">
-            <xsl:sort type="string" select="date"/>
+            <xsl:sort data-type="text" select="date"/>
           </xsl:apply-templates>
         </data>
       </xsl:template>


### PR DESCRIPTION
xslt-sort.xhtml - corrected the data-type attribute of the sort XSLT element.
The corresponding part of the XSLT spec:
https://www.w3.org/TR/1999/REC-xslt-19991116#sorting
It says:
<xsl:sort
   select = string-expression 
   lang = { nmtoken }
   **data-type** = { "**text**" | "number" | qname-but-not-ncname }
   order = { "ascending" | "descending" }
   case-order = { "upper-first" | "lower-first" } />